### PR TITLE
Catalog handling - link target attribute, user defined attributes

### DIFF
--- a/docs/Catalogs.md
+++ b/docs/Catalogs.md
@@ -22,6 +22,8 @@
     on a new line within the cell (CTRL-Enter within Excel).
 1. **Scripts** - comma-separated list of the scripts that should be associated with the catalog.  Each script takes the
     form `ScriptType|ScriptName`
+1. **User Defined Attributes** - comma-separated list of user defined attributes to be added to the catalog.  Each attribute takes the
+    form `AttributeName|AttributeValue`. This can be used to set the domain parameters: DOMAIN_ENTITY_FOR_ITEM, DOMAIN_ENTITY_ATTRIBUTE
 
 ### Valid script types
 

--- a/docs/Catalogs.md
+++ b/docs/Catalogs.md
@@ -23,7 +23,7 @@
 1. **Scripts** - comma-separated list of the scripts that should be associated with the catalog.  Each script takes the
     form `ScriptType|ScriptName`
 1. **User Defined Attributes** - comma-separated list of user defined attributes to be added to the catalog.  Each attribute takes the
-    form `AttributeName|AttributeValue`. This can be used to set the domain parameters: DOMAIN_ENTITY_FOR_ITEM, DOMAIN_ENTITY_ATTRIBUTE
+    form `AttributeName|AttributeValue`. This can be used to set the domain parameters: [DOMAIN_ENTITY_FOR_ITEM, DOMAIN_ENTITY_ATTRIBUTE](https://www.ibm.com/support/knowledgecenter/SSADN3_12.0.0/dev_soln/labels/con_customizinglabels.html)
 
 ### Valid script types
 

--- a/docs/Catalogs.md
+++ b/docs/Catalogs.md
@@ -14,7 +14,8 @@
 1. **Display Attribute** - full spec path of the display attribute to be used for the catalog
 1. **ACG** - name of the access control group to be associated to the catalog
 1. **Links** - comma-separated list of the links that should be defined for the catalog.  Each link takes the form
-    `FullSpecPathToLinkingAttribute|DestinationCatalogName`
+    `FullSpecPathToLinkingAttribute|DestinationCatalogName`.
+    Optionaly you can specify a display attribute instead of the primary key with `FullSpecPathToLinkingAttribute|DestinationCatalogName|FullSpecPathToDestinationCatalogAttribute`
 1. **Locations** - location hierarchy and details specified in the format:
     `HierarchyName=SecondarySpecName|InheritanceAttributeCollectionList`, where the `InheritanceAttributeCollectionList`
     is itself a comma-separated list of attribute collection names. Separate location hierarchies will need to be defined

--- a/src/main/java/com/ibm/mdmce/envtoolkit/deployment/CatalogHandler.java
+++ b/src/main/java/com/ibm/mdmce/envtoolkit/deployment/CatalogHandler.java
@@ -73,8 +73,31 @@ public class CatalogHandler extends BasicEntityHandler {
 				attr = spec.getAttributes().get(sLinkAttrPath);
 				bValid = (attr != null) && bValid;
 				if (attr == null)
-					err.println("WARNING (" + ctg.getName() + "): Unable to find attribute - " + ctg.getSpecName() + "/" + sLinkAttrPath);
+					err.println("WARNING (" + ctg.getName() + "): Unable to find link attribute - " + ctg.getSpecName() + "/" + sLinkAttrPath);
 				bValid = validateExists(sDestinationCtg, Catalog.class.getName(), ctg.getName()) && bValid;
+				//RS20210217: if we have a target attribute, check it exists 
+				String sDestAttr = (String)ctg.getLinkSpecPathToDestinationAttribute().get(sLinkAttrPath);
+				if (sDestAttr != null){
+					if (sDestAttr.equals("")){
+						err.println("WARNING (" + ctg.getName() + "): Empty target link attribute - " + sDestAttr);
+					}else{
+						String sDestSpecName = sDestAttr.split("\\Ω/\\E")[0];
+						bValid = validateExists(sDestSpecName, Spec.class.getName(), ctg.getName()) && bValid;
+						Spec specDestSpec = (Spec) getFromCache(sDestSpecName, Spec.class.getName(), false, false);
+						if( specDestSpec != null ){
+							String sDestAttrPath = sDestAttr.substring((sDestSpecName + "/").length());
+							Spec.Attribute attrDestAttr = specDestSpec.getAttributes().get(sDestAttrPath);
+							bValid = (attrDestAttr != null) && bValid;
+							if (attrDestAttr == null){
+								err.println("WARNING (" + ctg.getName() + "): Unable to find target link attribute - " + sDestSpecName + "/" + sDestAttrPath);
+							}else{//check the target attribute is valid for link: indexed
+								if (! attrDestAttr.isIndexed())
+									err.println("WARNING (" + ctg.getName() + "): Target link attribute is not indexed - " + sDestSpecName + "/" + sDestAttrPath);
+								bValid = (attrDestAttr.isIndexed()) && bValid;
+							}
+						}
+					}
+				}
 			}
 
 		}

--- a/src/main/java/com/ibm/mdmce/envtoolkit/deployment/CatalogHandler.java
+++ b/src/main/java/com/ibm/mdmce/envtoolkit/deployment/CatalogHandler.java
@@ -66,14 +66,15 @@ public class CatalogHandler extends BasicEntityHandler {
 				//String sLinkAttrPath = entry.getKey().replace(ctg.getSpecName() + "/", "");//RS 20151201 if attribute name ends with spec name, it is removed. ex : spec/attributeofspec/ --> /attributeof/ 
 				//as we just want to remove the spec name at the beginning of the string, this is better:				
 				String sLinkAttrPath = entry.getKey();
+				String sLinkAttrPathWoSpec = sLinkAttrPath;
 				if(sLinkAttrPath.startsWith(ctg.getSpecName() + "/")){
-					sLinkAttrPath = sLinkAttrPath.substring((ctg.getSpecName() + "/").length());
+					sLinkAttrPathWoSpec = sLinkAttrPath.substring((ctg.getSpecName() + "/").length());
 				}				
 				String sDestinationCtg = entry.getValue();
-				attr = spec.getAttributes().get(sLinkAttrPath);
+				attr = spec.getAttributes().get(sLinkAttrPathWoSpec);
 				bValid = (attr != null) && bValid;
 				if (attr == null)
-					err.println("WARNING (" + ctg.getName() + "): Unable to find link attribute - " + ctg.getSpecName() + "/" + sLinkAttrPath);
+					err.println("WARNING (" + ctg.getName() + "): Unable to find link attribute - " + ctg.getSpecName() + "/" + sLinkAttrPathWoSpec);
 				bValid = validateExists(sDestinationCtg, Catalog.class.getName(), ctg.getName()) && bValid;
 				//RS20210217: if we have a target attribute, check it exists 
 				String sDestAttr = (String)ctg.getLinkSpecPathToDestinationAttribute().get(sLinkAttrPath);
@@ -81,7 +82,7 @@ public class CatalogHandler extends BasicEntityHandler {
 					if (sDestAttr.equals("")){
 						err.println("WARNING (" + ctg.getName() + "): Empty target link attribute - " + sDestAttr);
 					}else{
-						String sDestSpecName = sDestAttr.split("\\Ω/\\E")[0];
+						String sDestSpecName = sDestAttr.split("/")[0];
 						bValid = validateExists(sDestSpecName, Spec.class.getName(), ctg.getName()) && bValid;
 						Spec specDestSpec = (Spec) getFromCache(sDestSpecName, Spec.class.getName(), false, false);
 						if( specDestSpec != null ){

--- a/src/main/java/com/ibm/mdmce/envtoolkit/deployment/model/Catalog.java
+++ b/src/main/java/com/ibm/mdmce/envtoolkit/deployment/model/Catalog.java
@@ -86,6 +86,7 @@ public class Catalog extends BasicEntity {
         ctg.primaryHierarchy = getFieldValue(PRIMARY_HIERARCHY, aFields);
         String sSecondaryHierarchies = getFieldValue(SECONDARY_HIERARCHIES, aFields);
         ctg.secondaryHierarchies.addAll(Arrays.asList(sSecondaryHierarchies.split(",")));
+        ctg.secondaryHierarchies.removeAll(Arrays.asList(""));//RS20210217 Remove empty strings
         ctg.inheritance = CSVParser.checkBoolean(getFieldValue(INHERIT, aFields));
         ctg.displayAttribute = getFieldValue(DISPLAY_ATTRIBUTE, aFields);
         ctg.acg = getFieldValue(ACG, aFields);


### PR DESCRIPTION
Adds support for 
- link target attribute ( #14 ), to display an indexed attribute instead of pk for links,
- user defined attributes ( #1 ), can be used to define [domains](https://www.ibm.com/support/knowledgecenter/SSADN3_12.0.0/dev_soln/labels/ref_uidomainentities.html) settings for custom icons/naming.


