### PR TITLE
Check boolean custom default

### DIFF
--- a/src/main/java/com/ibm/mdmce/envtoolkit/deployment/CSVParser.java
+++ b/src/main/java/com/ibm/mdmce/envtoolkit/deployment/CSVParser.java
@@ -201,15 +201,27 @@ public class CSVParser {
      * considered to be "true" and anything else is considered to be "false": {@literal yes}, {@literal true},
      * {@literal x}, and {@literal y}.
      * @param s the string to translate into a boolean value
+     * @param bDefault the boolean value to use when the string is null or empty
      * @return boolean
      */
-    public static boolean checkBoolean(String s) {
+    public static boolean checkBoolean(String s, boolean bDefault) {
         if (s == null || s.equals("")) {
-            return false;
+            return bDefault;
         } else {
             String sInsensitive = s.toUpperCase();
             return (sInsensitive.equals("YES") || sInsensitive.equals("TRUE") || sInsensitive.equals("X") || sInsensitive.equals("Y"));
         }
+    }
+
+    /**
+     * Attempts to translate the provided string into a boolean, where any of the following (case-insensitive) are
+     * considered to be "true" and anything else, including null or empty, is considered to be "false": {@literal yes}, {@literal true},
+     * {@literal x}, and {@literal y}.
+     * @param s the string to translate into a boolean value
+     * @return boolean
+     */
+    public static boolean checkBoolean(String s) {
+        return checkBoolean(s, false);
     }
 
     /**

--- a/src/main/java/com/ibm/mdmce/envtoolkit/deployment/model/Spec.java
+++ b/src/main/java/com/ibm/mdmce/envtoolkit/deployment/model/Spec.java
@@ -108,7 +108,7 @@ public class Spec extends BasicEntity {
         attr.link = CSVParser.checkBoolean(sLink);
         attr.min = CSVParser.checkInteger(getFieldValue(MIN_OCCUR, aFields), attr.min);
         attr.max = CSVParser.checkInteger(getFieldValue(MAX_OCCUR, aFields), attr.max);
-        attr.editable = CSVParser.checkBoolean(getFieldValue(EDITABLE, aFields));
+        attr.editable = CSVParser.checkBoolean(getFieldValue(EDITABLE, aFields), attr.editable);//RS20210217 if empty, respects default
         attr.nonPersisted = CSVParser.checkBoolean(getFieldValue(NON_PERSISTED, aFields));
         attr.defaultValue = getFieldValue(DEFAULT_VALUE, aFields);
         attr.length = CSVParser.checkInteger(getFieldValue(LENGTH, aFields), attr.length);


### PR DESCRIPTION
Enable checkBoolean to have a default value to use when the string is empty.
checkBoolean(String s, boolean bDefault)
And use it when parsing boolean for specs.csv 'isEditable' to respect the default value of 'true'